### PR TITLE
Fix "openio_bootstrap" conditional

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,5 @@
   tags:
     - openio_bootstrap
   include: bootstrap.yml
-  when:
-    - openio_bootstrap == true
+  when: openio_bootstrap
 ...


### PR DESCRIPTION
- It's a single condition, put it on the "when" line
- The "== true" test is too strict, the variable is passed from
  StackStorm as "True" (yes, uppercase) and this was not matching