### PR TITLE
Fix group membership tests in "Update meta[01] services" tasks

### DIFF
--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -34,12 +34,12 @@
 - name: Update meta0 services
   command: "{{ openio_gridinit_cmd }} restart @meta0"
   when:
-    - inventory_hostname == groups['openio_directory_m0']
+    - inventory_hostname in groups['openio_directory_m0']
 
 - name: Update meta1 services
   command: "{{ openio_gridinit_cmd }} restart @meta1"
   when:
-    - inventory_hostname == groups['openio_directory_m1']
+    - inventory_hostname in groups['openio_directory_m1']
 
 - name: "Starting services for namespace {{ openio_namespace }}"
   command: "{{ openio_gridinit_cmd }} start"


### PR DESCRIPTION
The test were always evaluating to false, as a string is always
different from a list.