### PR TITLE
Rebase role for latest openio sds version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ openio_storage_policy: THREECOPIES
 openio_service_update_policy: "{'meta2'=>'KEEP|3|1|','sqlx'=>'KEEP|3|1|','rdir'=>'KEEP|1|1|user_is_a_service=rawx'}"
 openio_gridinit_cmd: /usr/bin/gridinit_cmd
 
-openio_network_device_internal: '${ipaddress}'
+openio_network_private_ipaddress: '${ipaddress}'
 openio_network_public_ipaddress: '${ipaddress}'
 
 openio_swift_workers: 2


### PR DESCRIPTION
The commit https://github.com/open-io/puppet-openiosds/commit/d0f0a2bfc89bce7e0a001227a5f3a62e15e830f3 moved some variables around in the puppet manifest. So the puppet manifest built by this role is no longer working.

Also the variable `openio_network_device_internal` seems to be renamed in `openio_network_private_ipaddress`