### PR TITLE
Bootstrap: wait for ZK to be online before continuing

### DIFF
--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -15,6 +15,14 @@
   when:
     - inventory_hostname == groups['openio_zk_cluster'][0]
 
+- name: Wait for Zookeeper to be online
+  shell: echo ruok | nc {{item}} 6005
+  register: result
+  until: result.stdout.find("imok") != -1
+  retries: 10
+  delay: 3
+  with_items: "{{openio_zk_cluster_ip}}"
+
 - name: "Bootstrapping ZooKeeper for namespace {{ openio_namespace }}"
   command: "{{ openio_zookeeper_bootstrap_cmd }} {{ openio_namespace }} {{ openio_zookeeper_bootstrap_options }}"
   when:


### PR DESCRIPTION
Zookeeper doesn't achieve "OK" state once puppet apply is done, causing the `zk-bootstrap` that follows immediately to fail sometimes with a `server refused to accept the client` error.

This fix forces the playbook to wait until all ZK instances are fully online.

This makes use of `netcat`, which might not be installed on all systems. Additional checks might thus be required.