### PR TITLE
Bootstrap: restart M0/M1 to avoid election errors

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,36 @@
 ---
 # handlers file for openio-sds
+
+- name: "Restart meta0 meta1"
+  changed_when: true
+  debug:
+      msg: "Restarting meta0 and meta1 on namespace {{openio_namespace}}"
+  notify:
+      - "Restart meta0 meta1: pid"
+      - "Restart meta0 meta1: restart"
+      - "Restart meta0 meta1: wait"
+      - "Restart meta0 meta1: cleanup"
+
+- name: "Restart meta0 meta1: pid"
+  changed_when: true
+  shell: "{{ openio_gridinit_cmd }} status2 @meta0 @meta1 | grep {{openio_namespace}} | awk '{print $3}'"
+  register: m0m1_pid
+
+- name: "Restart meta0 meta1: restart"
+  shell: "{{ openio_gridinit_cmd }} restart $({{ openio_gridinit_cmd }} status @meta0 @meta1 |
+          grep ' {{ openio_namespace }},' | awk '{print $1}')"
+
+- name: "Restart meta0 meta1: wait"
+  changed_when: true
+  wait_for:
+    path: "/proc/{{ item }}/status"
+    state: absent
+  with_items: "{{ m0m1_pid.stdout_lines }}"
+  ignore_errors: yes
+  register: m0m1_pid_killed
+  timeout: 30
+
+- name: "Restart meta0 meta1: cleanup"
+  changed_when: true
+  shell: "kill -9 {{ item }}"
+  with_items: "{{ m0m1_pid_killed.results | select('failed') | map(attribute='item') | list }}"

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -28,27 +28,10 @@
   when:
     - inventory_hostname == groups['openio_zk_cluster'][0]
       and openio_zk_status.rc != 0
+  notify: "Restart meta0 meta1"
 
-- name: "Gather PIDs of meta0/meta1 services"
-  shell: "{{ openio_gridinit_cmd }} status2 @meta0 @meta1 | grep {{openio_namespace}} | awk '{print $3}'"
-  register: m0m1_pid
-
-- name: "Restart meta0/meta1 services"
-  shell: "{{ openio_gridinit_cmd }} restart $({{ openio_gridinit_cmd }} status @meta0 @meta1 |
-          grep ' {{ openio_namespace }},' | awk '{print $1}')"
-
-- name: "Check that meta0/meta1 have restarted"
-  wait_for:
-    path: "/proc/{{ item }}/status"
-    state: absent
-  with_items: "{{ m0m1_pid.stdout_lines }}"
-  ignore_errors: yes
-  register: m0m1_pid_killed
-  timeout: 30
-
-- name: "Kill remaining meta0/meta1"
-  shell: "kill -9 {{ item }}"
-  with_items: "{{ m0m1_pid_killed.results | select('failed') | map(attribute='item') | list }}"
+- name: "Run handlers"
+  meta: flush_handlers
 
 - name: "Unlock scores on meta0/meta1 services"
   shell: "{{ openio_cli_path }} cluster unlockall meta0 meta1 --oio-ns={{ openio_namespace }} &&
@@ -58,27 +41,10 @@
   command: "{{ openio_cli_path }} --oio-ns={{ openio_namespace }} directory bootstrap --replicas {{ openio_replicas }} --no-rdir"
   when:
     - inventory_hostname == groups['openio_conscience'][0]
+  notify: "Restart meta0 meta1"
 
-- name: "Gather PIDs of meta0/meta1 services"
-  shell: "{{ openio_gridinit_cmd }} status2 @meta0 @meta1 | grep {{openio_namespace}} | awk '{print $3}'"
-  register: m0m1_pid
-
-- name: "Restart meta0/meta1 services"
-  shell: "{{ openio_gridinit_cmd }} restart $({{ openio_gridinit_cmd }} status @meta0 @meta1 |
-          grep ' {{ openio_namespace }},' | awk '{print $1}')"
-
-- name: "Check that meta0/meta1 have restarted"
-  wait_for:
-    path: "/proc/{{ item }}/status"
-    state: absent
-  with_items: "{{ m0m1_pid.stdout_lines }}"
-  ignore_errors: yes
-  register: m0m1_pid_killed
-  timeout: 30
-
-- name: "Kill remaining meta0/meta1"
-  shell: "kill -9 {{ item }}"
-  with_items: "{{ m0m1_pid_killed.results | select('failed') | map(attribute='item') | list }}"
+- name: "Run handlers"
+  meta: flush_handlers
 
 - name: "Starting services for namespace {{ openio_namespace }}"
   command: "{{ openio_gridinit_cmd }} start @{{ openio_namespace}}"

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -50,21 +50,9 @@
   shell: "kill -9 {{ item }}"
   with_items: "{{ m0m1_pid_killed.results | select('failed') | map(attribute='item') | list }}"
 
-- name: "Unlocking namespace {{ openio_namespace }}"
-  command: "{{ openio_cli_path }} --oio-ns={{ openio_namespace }} cluster unlockall"
-  when:
-    - inventory_hostname == groups['openio_conscience'][0]
-
-- name: "Waiting for {{  groups['openio_directory_m0'] | length }} meta0 and {{ groups['openio_directory_m1'] | length }}
-         meta1 scores to increase"
-  shell: "{{ openio_cli_path }} cluster list meta0 meta1 --oio-ns={{ openio_namespace }}
-          -f value -c Score | grep -c '^0$' || true"
-  register: metas_count
-  until: "(metas_count.stdout | int) == 0"
-  retries: 10
-  delay: 1
-  when:
-    - inventory_hostname == groups['openio_conscience'][0]
+- name: "Unlock scores on meta0/meta1 services"
+  shell: "{{ openio_cli_path }} cluster unlockall meta0 meta1 --oio-ns={{ openio_namespace }} &&
+          {{ openio_cli_path }} cluster wait      meta0 meta1 --oio-ns={{ openio_namespace }}"
 
 - name: "Bootstrapping OpenIO namespace {{ openio_namespace }} with {{ openio_replicas }} replicas"
   command: "{{ openio_cli_path }} --oio-ns={{ openio_namespace }} directory bootstrap --replicas {{ openio_replicas }} --no-rdir"
@@ -95,15 +83,9 @@
 - name: "Starting services for namespace {{ openio_namespace }}"
   command: "{{ openio_gridinit_cmd }} start @{{ openio_namespace}}"
 
-- name: "Waiting for scores to increase"
-  shell: "{{ openio_cli_path }} cluster list --oio-ns={{ openio_namespace }}
-          -f value -c Score | grep -c '^0$' || true"
-  register: unscored_count
-  until: "(unscored_count.stdout | int) == 0"
-  retries: 10
-  delay: 1
-  when:
-    - inventory_hostname == groups['openio_conscience'][0]
+- name: "Unlock scores"
+  shell: "{{ openio_cli_path }} cluster unlockall --oio-ns={{ openio_namespace }} &&
+          {{ openio_cli_path }} cluster wait      --oio-ns={{ openio_namespace }}"
 
 - name: "Bootstrapping Reverse Directory for namespace {{ openio_namespace }}"
   command: "{{ openio_cli_path }} --oio-ns={{ openio_namespace }} volume admin bootstrap"

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -71,10 +71,26 @@
   when:
     - inventory_hostname == groups['openio_conscience'][0]
 
-- name: "Update meta0/meta1 services"
-  command: "{{ openio_gridinit_cmd }} restart @meta0 @meta1"
-  when:
-    - inventory_hostname in (groups['openio_directory_m1'] + groups['openio_directory_m0'])
+- name: "Gather PIDs of meta0/meta1 services"
+  shell: "{{ openio_gridinit_cmd }} status2 @meta0 @meta1 | grep {{openio_namespace}} | awk '{print $3}'"
+  register: m0m1_pid
+
+- name: "Restart meta0/meta1 services"
+  shell: "{{ openio_gridinit_cmd }} restart $({{ openio_gridinit_cmd }} status @meta0 @meta1 |
+          grep ' {{ openio_namespace }},' | awk '{print $1}')"
+
+- name: "Check that meta0/meta1 have restarted"
+  wait_for:
+    path: "/proc/{{ item }}/status"
+    state: absent
+  with_items: "{{ m0m1_pid.stdout_lines }}"
+  ignore_errors: yes
+  register: m0m1_pid_killed
+  timeout: 30
+
+- name: "Kill remaining meta0/meta1"
+  shell: "kill -9 {{ item }}"
+  with_items: "{{ m0m1_pid_killed.results | select('failed') | map(attribute='item') | list }}"
 
 - name: "Starting services for namespace {{ openio_namespace }}"
   command: "{{ openio_gridinit_cmd }} start @{{ openio_namespace}}"

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -55,30 +55,37 @@
   when:
     - inventory_hostname == groups['openio_conscience'][0]
 
-- name: Waiting for scores to increase
-  pause:
-    seconds: 10
+- name: "Waiting for {{  groups['openio_directory_m0'] | length }} meta0 and {{ groups['openio_directory_m1'] | length }}
+         meta1 scores to increase"
+  shell: "{{ openio_cli_path }} cluster list meta0 meta1 --oio-ns={{ openio_namespace }}
+          -f value -c Score | grep -c '^0$' || true"
+  register: metas_count
+  until: "(metas_count.stdout | int) == 0"
+  retries: 10
+  delay: 1
+  when:
+    - inventory_hostname == groups['openio_conscience'][0]
 
 - name: "Bootstrapping OpenIO namespace {{ openio_namespace }} with {{ openio_replicas }} replicas"
   command: "{{ openio_cli_path }} --oio-ns={{ openio_namespace }} directory bootstrap --replicas {{ openio_replicas }} --no-rdir"
   when:
     - inventory_hostname == groups['openio_conscience'][0]
 
-- name: Update meta0 services
-  command: "{{ openio_gridinit_cmd }} restart @meta0"
+- name: "Update meta0/meta1 services"
+  command: "{{ openio_gridinit_cmd }} restart @meta0 @meta1"
   when:
-    - inventory_hostname in groups['openio_directory_m0']
-
-- name: Update meta1 services
-  command: "{{ openio_gridinit_cmd }} restart @meta1"
-  when:
-    - inventory_hostname in groups['openio_directory_m1']
+    - inventory_hostname in (groups['openio_directory_m1'] + groups['openio_directory_m0'])
 
 - name: "Starting services for namespace {{ openio_namespace }}"
-  command: "{{ openio_gridinit_cmd }} start"
+  command: "{{ openio_gridinit_cmd }} start @{{ openio_namespace}}"
 
-- name: "Unlocking namespace {{ openio_namespace }}"
-  command: "{{ openio_cli_path }} --oio-ns={{ openio_namespace }} cluster unlockall"
+- name: "Waiting for scores to increase"
+  shell: "{{ openio_cli_path }} cluster list --oio-ns={{ openio_namespace }}
+          -f value -c Score | grep -c '^0$' || true"
+  register: unscored_count
+  until: "(unscored_count.stdout | int) == 0"
+  retries: 10
+  delay: 1
   when:
     - inventory_hostname == groups['openio_conscience'][0]
 

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -30,12 +30,12 @@
       and openio_zk_status.rc != 0
 
 - name: "Gather PIDs of meta0/meta1 services"
-  shell: "{{ openio_gridinit_cmd }} status2 @meta0 @meta1 | grep {{openio_namespace}} | awk '{print $3;}'"
+  shell: "{{ openio_gridinit_cmd }} status2 @meta0 @meta1 | grep {{openio_namespace}} | awk '{print $3}'"
   register: m0m1_pid
 
 - name: "Restart meta0/meta1 services"
   shell: "{{ openio_gridinit_cmd }} restart $({{ openio_gridinit_cmd }} status @meta0 @meta1 |
-          grep -e ' {{ openio_namespace }},' | awk '{print $1}')"
+          grep ' {{ openio_namespace }},' | awk '{print $1}')"
 
 - name: "Check that meta0/meta1 have restarted"
   wait_for:

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -29,6 +29,27 @@
     - inventory_hostname == groups['openio_zk_cluster'][0]
       and openio_zk_status.rc != 0
 
+- name: "Gather PIDs of meta0/meta1 services"
+  shell: "{{ openio_gridinit_cmd }} status2 @meta0 @meta1 | grep {{openio_namespace}} | awk '{print $3;}'"
+  register: m0m1_pid
+
+- name: "Restart meta0/meta1 services"
+  shell: "{{ openio_gridinit_cmd }} restart $({{ openio_gridinit_cmd }} status @meta0 @meta1 |
+          grep -e ' {{ openio_namespace }},' | awk '{print $1}')"
+
+- name: "Check that meta0/meta1 have restarted"
+  wait_for:
+    path: "/proc/{{ item }}/status"
+    state: absent
+  with_items: "{{ m0m1_pid.stdout_lines }}"
+  ignore_errors: yes
+  register: m0m1_pid_killed
+  timeout: 30
+
+- name: "Kill remaining meta0/meta1"
+  shell: "kill -9 {{ item }}"
+  with_items: "{{ m0m1_pid_killed.results | select('failed') | map(attribute='item') | list }}"
+
 - name: "Unlocking namespace {{ openio_namespace }}"
   command: "{{ openio_cli_path }} --oio-ns={{ openio_namespace }} cluster unlockall"
   when:


### PR DESCRIPTION
Meta0 and Meta1 services are sometimes not properly restarted, causing errors down the bootstrap pipeline. (e.g. `META1 error: Open/Lock error: Election failed [E000][meta1] (HTTP 503) (STATUS 503)` when doing `openio volume admin bootstrap`.

This fix introduces some hardening by waiting for meta(0,1) services to reboot, and then killing them if necessary. It was also made compatible with multi-namespace deployments.