### PR TITLE
Fix update without bootstrapping, proper rdir assignment

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -34,3 +34,48 @@
   changed_when: true
   shell: "kill -9 {{ item }}"
   with_items: "{{ m0m1_pid_killed.results | select('failed') | map(attribute='item') | list }}"
+
+
+
+- name: "Assign rdir"
+  changed_when: true
+  debug:
+      msg: "Updating rdir assignment on {{openio_namespace}}"
+  notify:
+      - "Assign rdir: save locked"
+      - "Assign rdir: unlock"
+      - "Assign rdir: assign"
+      - "Assign rdir: lock"
+
+- name: "Assign rdir: save locked"
+  shell: "{{ openio_cli_path }} cluster list --oio-ns={{ openio_namespace }} -f value | awk '{if($7==0) print $1,$2;}'"
+  register: locked_services
+  changed_when: true
+  when:
+      - openio_bootstrap != 'True'
+      - inventory_hostname == groups['openio_conscience'][0]
+
+# TODO: Without an update in SDS to be able to assign on locked rawx, we need to unlock rawx scores for a moment
+# in order to perform rdir assignment.
+# See https://github.com/open-io/oio-sds/issues/1337
+- name: "Assign rdir: unlock"
+  shell: "{{ openio_cli_path }} cluster unlockall --oio-ns={{ openio_namespace }} rawx rdir &&
+          {{ openio_cli_path }} cluster wait      --oio-ns={{ openio_namespace }} rawx rdir"
+  changed_when: true
+  when: openio_bootstrap != 'True'
+
+- name: "Assign rdir: assign"
+  command: "{{ openio_cli_path }} --oio-ns={{ openio_namespace }} volume admin bootstrap"
+  changed_when: true
+  when:
+      - inventory_hostname == groups['openio_conscience'][0]
+
+- name: "Assign rdir: lock"
+  shell: "{{ openio_cli_path }} cluster lock --oio-ns={{ openio_namespace }} {{ item }} -f yaml"
+  changed_when: true
+  with_items:
+      - "{{ locked_services.stdout_lines }}"
+  when:
+      - openio_bootstrap != 'True'
+      - inventory_hostname == groups['openio_conscience'][0]
+...

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -1,13 +1,4 @@
 ---
-- name: "Adapting to Puppet version"
-  shell: "puppet --version|cut -c1"
-  register: puppet_majorversion
-
-- name: "Applying Puppet manifest for namespace {{ openio_namespace }}"
-  command: "{{ openio_puppet4_apply if ( puppet_majorversion == '4' ) else openio_puppet3_apply }} {{ openio_puppet_manifest }}/{{ openio_namespace|lower }}.pp"
-  register: puppet_result
-  changed_when: puppet_result.rc == 2
-
 - name: Check ZooKeeper status
   shell: "echo \"ls /hc/ns/{{ openio_namespace }}\" | {{ openio_zookeeper_cli_path }} -server {{ openio_zk_cluster_ip[0] }}:6005 2>/dev/null | grep -qe srv"
   register: openio_zk_status

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -43,9 +43,8 @@
 - name: "Unlock scores"
   shell: "{{ openio_cli_path }} cluster unlockall --oio-ns={{ openio_namespace }} &&
           {{ openio_cli_path }} cluster wait      --oio-ns={{ openio_namespace }}"
+  notify: "Assign rdir"
 
-# - name: "Bootstrapping Reverse Directory for namespace {{ openio_namespace }}"
-#   command: "{{ openio_cli_path }} --oio-ns={{ openio_namespace }} volume admin bootstrap"
-#   when:
-#     - inventory_hostname == groups['openio_conscience'][0]
+- name: "Run handlers"
+  meta: flush_handlers
 ...

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -44,8 +44,8 @@
   shell: "{{ openio_cli_path }} cluster unlockall --oio-ns={{ openio_namespace }} &&
           {{ openio_cli_path }} cluster wait      --oio-ns={{ openio_namespace }}"
 
-- name: "Bootstrapping Reverse Directory for namespace {{ openio_namespace }}"
-  command: "{{ openio_cli_path }} --oio-ns={{ openio_namespace }} volume admin bootstrap"
-  when:
-    - inventory_hostname == groups['openio_conscience'][0]
+# - name: "Bootstrapping Reverse Directory for namespace {{ openio_namespace }}"
+#   command: "{{ openio_cli_path }} --oio-ns={{ openio_namespace }} volume admin bootstrap"
+#   when:
+#     - inventory_hostname == groups['openio_conscience'][0]
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,11 @@
     mode: 0751
   with_items: "{{ openio_data_mounts }} + {{ openio_metadata_mounts }}"
 
+- name: "Update configuration on servers"
+  tags:
+    - install
+  include: update.yml
+
 - name: "Bootstrapping OpenIO for namespace {{ openio_namespace }}"
   tags:
     - openio_bootstrap

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -1,0 +1,11 @@
+---
+- name: "Adapting to Puppet version"
+  shell: "puppet --version|cut -c1"
+  register: puppet_majorversion
+
+- name: "Applying Puppet manifest for namespace {{ openio_namespace }}"
+  command: "{{ openio_puppet4_apply if ( puppet_majorversion == '4' ) else openio_puppet3_apply }} \
+            {{ openio_puppet_manifest }}/{{ openio_namespace|lower }}.pp"
+  register: puppet_result
+  changed_when: puppet_result.rc == 2
+...

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -13,39 +13,14 @@
   shell: "gridinit_cmd restart $({{openio_gridinit_cmd}} status | \
           grep {{openio_namespace}} | grep conscienceagent | awk '{ print $1 }')"
 
-# FIXME: Currently there isn't any way to check that all services have registered
-# in the conscience, so we wait
+# NOTE: Currently there isn't any way to check that all services have registered
+# in the conscience, so we just have to wait
 - name: "Wait to make sure  all services to be registered in the conscience"
   wait_for: timeout=10
   delegate_to: "{{ groups['openio_conscience'][0] }}"
   when: openio_bootstrap != 'True'
+  notify: "Assign rdir"
 
-- name: "Store a list of services with locked scores which will have to be relocked after setup"
-  shell: "{{ openio_cli_path }} cluster list --oio-ns={{ openio_namespace }} -f value | awk '{if($7==0) print $1,$2;}'"
-  register: openio_locked
-  when:
-      - openio_bootstrap != 'True'
-      - inventory_hostname == groups['openio_conscience'][0]
-
-# TODO: Without an update in SDS to be able to assign on locked rawx, we need to unlock rawx scores for a moment
-# in order to perform rdir assignment
-# See https://github.com/open-io/oio-sds/issues/1337
-- name: "Unlock scores for rawx/rdir"
-  shell: "{{ openio_cli_path }} cluster unlockall --oio-ns={{ openio_namespace }} rawx rdir &&
-          {{ openio_cli_path }} cluster wait      --oio-ns={{ openio_namespace }} rawx rdir"
-  when: openio_bootstrap != 'True'
-
-- name: "Update Reverse Directory assignment for namespace {{ openio_namespace }}"
-  command: "{{ openio_cli_path }} --oio-ns={{ openio_namespace }} volume admin bootstrap"
-  when:
-      - openio_bootstrap != 'True'
-      - inventory_hostname == groups['openio_conscience'][0]
-
-- name: "Lock scores on previously unlocked services"
-  shell: "{{ openio_cli_path }} cluster lock --oio-ns={{ openio_namespace }} {{ item }} -f yaml"
-  with_items:
-      - "{{ openio_locked.stdout_lines }}"
-  when:
-      - openio_bootstrap != 'True'
-      - inventory_hostname == groups['openio_conscience'][0]
+- name: "Run handlers"
+  meta: flush_handlers
 ...

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -8,4 +8,44 @@
             {{ openio_puppet_manifest }}/{{ openio_namespace|lower }}.pp"
   register: puppet_result
   changed_when: puppet_result.rc == 2
+
+- name: "Restart conscience agent to update service list"
+  shell: "gridinit_cmd restart $({{openio_gridinit_cmd}} status | \
+          grep {{openio_namespace}} | grep conscienceagent | awk '{ print $1 }')"
+
+# FIXME: Currently there isn't any way to check that all services have registered
+# in the conscience, so we wait
+- name: "Wait to make sure  all services to be registered in the conscience"
+  wait_for: timeout=10
+  delegate_to: "{{ groups['openio_conscience'][0] }}"
+  when: openio_bootstrap != 'True'
+
+- name: "Store a list of services with locked scores which will have to be relocked after setup"
+  shell: "{{ openio_cli_path }} cluster list --oio-ns={{ openio_namespace }} -f value | awk '{if($7==0) print $1,$2;}'"
+  register: openio_locked
+  when:
+      - openio_bootstrap != 'True'
+      - inventory_hostname == groups['openio_conscience'][0]
+
+# TODO: Without an update in SDS to be able to assign on locked rawx, we need to unlock rawx scores for a moment
+# in order to perform rdir assignment
+# See https://github.com/open-io/oio-sds/issues/1337
+- name: "Unlock scores for rawx/rdir"
+  shell: "{{ openio_cli_path }} cluster unlockall --oio-ns={{ openio_namespace }} rawx rdir &&
+          {{ openio_cli_path }} cluster wait      --oio-ns={{ openio_namespace }} rawx rdir"
+  when: openio_bootstrap != 'True'
+
+- name: "Update Reverse Directory assignment for namespace {{ openio_namespace }}"
+  command: "{{ openio_cli_path }} --oio-ns={{ openio_namespace }} volume admin bootstrap"
+  when:
+      - openio_bootstrap != 'True'
+      - inventory_hostname == groups['openio_conscience'][0]
+
+- name: "Lock scores on previously unlocked services"
+  shell: "{{ openio_cli_path }} cluster lock --oio-ns={{ openio_namespace }} {{ item }} -f yaml"
+  with_items:
+      - "{{ openio_locked.stdout_lines }}"
+  when:
+      - openio_bootstrap != 'True'
+      - inventory_hostname == groups['openio_conscience'][0]
 ...


### PR DESCRIPTION
This fixes an issue where the openio_bootstrap token prevents puppet apply when it is not set. Also, proper rdir to rawx assignment has been added, especially when scaling the cluster. Special attention has been given to make sure scores stay locked on new nodes when scaling (see related issue: https://github.com/open-io/oio-sds/issues/1337)