### PR TITLE
Fix redis sentinel "redis_host" configuration

### DIFF
--- a/templates/openio.pp.j2
+++ b/templates/openio.pp.j2
@@ -89,7 +89,7 @@ openiosds::redissentinel {'redissentinel-1':
   ipaddress   => "{{ openio_network_private_ipaddress }}",
   dir         => "{{ partition.mountpoint }}/{{ openio_namespace }}/redissentinel-1",
   master_name => '{{ openio_namespace }}-master-1',
-  redis_host  => "{{ openio_network_private_ipaddress }}",
+  redis_host  => "{{ openio_redis_cluster_ip[0] }}",
 }
 openiosds::redis {'redis-1':
   num       => 1,


### PR DESCRIPTION
It was pointing at itself, which made each redis_cluster memeber its own
master, not related to the other ones.

Make it point at the master (first host mentionned in the redis_sentinel
ansible group)