### PR TITLE
Disable syncookies

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,6 @@ openio_sds_sysctl_entries:
   net.ipv4.udp_wmem_min: 16384
   net.ipv4.tcp_max_tw_buckets: 1440000
   net.ipv4.tcp_tw_reuse: 1
-  net.ipv4.tcp_syncookies: 1
+  net.ipv4.tcp_syncookies: 0
   net.ipv4.tcp_tw_recycle: 1
 ...


### PR DESCRIPTION
We encountered several times this problem during heavy load.
This deactivation represents a danger if the cluster is exposed on the internet.

The cluster owner will have to adjust the `net.ipv4.tcp_max_syn_backlog` and reset the `net.ipv4.tcp_syncookies` to 1