### PR TITLE
[RFC] Move `timeout` to where it belongs, the `wait_for` task

### DIFF
--- a/tasks/restart_m0m1.yml
+++ b/tasks/restart_m0m1.yml
@@ -20,11 +20,11 @@
   wait_for:
     path: "/proc/{{ item }}/status"
     state: absent
+    timeout: 30
   when: (item | int) != -1
   with_items: "{{ m0m1_pids.stdout_lines }}"
   ignore_errors: true
   register: m0m1_pids_killed
-  timeout: 30
 
 - name: "Restart meta0 meta1: cleanup stray processes by force-killing"
   changed_when: true


### PR DESCRIPTION
Should fix ansible message:
[WARNING]: Ignoring invalid attribute: timeout

Fixes: 0b6b99524ae9eaeb91772d5fe1fc4706ce8505ac
Carried-on-by: f60f1cd006d8ad8a18b15fda044f06adbbe503dd

Ref:
* http://docs.ansible.com/ansible/latest/reference_appendices/playbooks_keywords.html#task
* http://docs.ansible.com/ansible/latest/modules/wait_for_module.html