### PR TITLE
Fix openio_swift_middleware_containerhierarchy

### DIFF
--- a/templates/openio.pp.j2
+++ b/templates/openio.pp.j2
@@ -166,9 +166,9 @@ openiosds::oioswift {'oioswift-1':
 
   sds_pool_maxsize => '{{ openio_sds_pool_maxsize }}',
   {%- endif %}
-  {%- if openio_swift_middleware_containerhierarchy is defined  and openio_swift_middleware_containerhierarchy %}
+  {%- if openio_swift_middleware_containerhierarchy is defined %}
 
-  middleware_containerhierarchy => true,
+  middleware_containerhierarchy => {{ openio_swift_middleware_containerhierarchy }},
   {%- endif %}
   {%- if openio_swift_tempauth_users is defined %}
 


### PR DESCRIPTION
Always pass the parameter if it is given to the role, so that we
override the default value whichever it is.