### PR TITLE
Add a retry loop around zookeeper bootstrap for namespace

### DIFF
--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -30,6 +30,10 @@
   when:
     - inventory_hostname == groups['openio_zk_cluster'][0]
     - openio_zk_status.rc != 0
+  register: zk_bootstrap
+  until: zk_bootstrap is success
+  retries: 5
+  delay: 10
 
 - name: 'Restart meta0 & meta1'
   include_tasks: restart_m0m1.yml

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -31,9 +31,18 @@
     - inventory_hostname == groups['openio_zk_cluster'][0]
     - openio_zk_status.rc != 0
   register: zk_bootstrap
-  until: zk_bootstrap is success
-  retries: 5
-  delay: 10
+  until: zk_bootstrap.rc == 0
+  retries: 3
+  delay: 5
+  ignore_errors: true
+  failed_when: false
+
+- name: "Bootstrapping ZooKeeper for namespace {{ openio_namespace }} in slow mode"
+  command: "{{ openio_zookeeper_bootstrap_cmd }} {{ openio_namespace }} {{ openio_zookeeper_bootstrap_options }} --slow"
+  when:
+    - inventory_hostname == groups['openio_zk_cluster'][0]
+    - openio_zk_status.rc != 0
+    - zk_bootstrap.rc != 0
 
 - name: 'Restart meta0 & meta1'
   include_tasks: restart_m0m1.yml


### PR DESCRIPTION
ZK bootstrap can fail as seen on OpenStack Ubuntu xenial VMs

This has been tested to work around the problem, first bootstrap failed,
then the first retry worked