### PR TITLE
Add a way to make locations more accurate

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,8 @@ openio_data_mounts:
 openio_metadata_mounts:
   - { mountpoint: "/var/lib/oio/sds" }
 
+openio_rawx_accurate_location: false
+
 #openio_puppet_manifest: '/etc/oio/sds'
 openio_puppet_manifest: '/root'
 

--- a/templates/openio.pp.j2
+++ b/templates/openio.pp.j2
@@ -121,6 +121,9 @@ openiosds::rawx {'rawx-{{ loop.index }}':
   ipaddress    => "{{ openio_network_private_ipaddress }}",
   port         => {{ 6200 + loop.index }},
   documentRoot => "{{ partition.mountpoint }}/{{ openio_namespace }}/rawx-{{ loop.index }}",
+  {%- if openio_rawx_accurate_location %}
+  location  => "${hostname}.{{ loop.index }}",
+  {%- endif %}
 }
 openiosds::rdir {'rdir-{{ loop.index }}':
   num       => {{ loop.index }},


### PR DESCRIPTION
When the flag is set, the location of rawx services will be set to [hostname].[id], instead of [hostname].