### PR TITLE
Change meta0/meta1 stop timeout from 30 to 35 seconds

### DIFF
--- a/tasks/restart_m0m1.yml
+++ b/tasks/restart_m0m1.yml
@@ -32,7 +32,7 @@
   wait_for:
     path: "/proc/{{ pid }}/status"
     state: absent
-    timeout: 30
+    timeout: 35
   when:
     - m0m1_svcs.stdout != ""
     - (pid | int) != -1


### PR DESCRIPTION
Let a little bit of room to avoid SIGKILL on services that are stopping.